### PR TITLE
Corrected a typo at StartupMap.cs

### DIFF
--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMap.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMap.cs
@@ -24,7 +24,7 @@
 
         app.Run(async context =>
         {
-            await context.Response.WriteAsync("Hello from non-Map delegate. <p>");
+            await context.Response.WriteAsync("<p>Hello from non-Map delegate.</p>");
         });
     }
 }


### PR DESCRIPTION
I noticed a typo in an article on learn.microsoft.com. The tag was open, but not closed. I think it was supposed to use "Hello from non-Map delegate." inside the p tag.

If so, I suggest using this quick fix. Thanks!